### PR TITLE
Add endianless byte dtype

### DIFF
--- a/docs/data_models/data_type.md
+++ b/docs/data_models/data_type.md
@@ -34,6 +34,11 @@
     :member-order: bysource
 ```
 
+The enumeration also includes ``ScalarType.BYTE`` which represents a single byte
+of raw data that is preserved without any endianness conversion. This is useful
+for unknown or vendor specific trace header fields that need to maintain bitwise
+fidelity.
+
 ```{eval-rst}
 .. autopydantic_model:: HeaderSpec
     :inherited-members: BaseModel

--- a/src/segy/schema/format.py
+++ b/src/segy/schema/format.py
@@ -24,6 +24,7 @@ class ScalarType(StrEnum):
     UINT32 = "uint32"
     UINT16 = "uint16"
     UINT8 = "uint8"
+    BYTE = "V1"
     FLOAT64 = "float64"
     FLOAT32 = "float32"
     FLOAT16 = "float16"
@@ -39,6 +40,9 @@ class ScalarType(StrEnum):
         # Special case for IBM 32-bit float
         if self.value == "ibm32":
             return np.dtype("uint32")
+
+        if self.value == "V1":
+            return np.dtype("|V1")
 
         return np.dtype(self.value)
 


### PR DESCRIPTION
## Summary
- add `BYTE` to ScalarType for endianless single bytes
- test support for endianless byte header fields
- document endianless byte usage

## Testing
- `ruff check src/segy/schema/format.py tests/test_schema_data_type.py`
- `black --check src/segy/schema/format.py tests/test_schema_data_type.py`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'fsspec')*


------
https://chatgpt.com/codex/tasks/task_e_685cac6bc2ac833083186f087e02baf2